### PR TITLE
Add support for capital @Override decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Both jsdoc tags and decorators are accepted by default. If you want to force one
     }
 ```
 
-By default, the fixer will add a jsdoc tag, specifying the `decorator` option will also use the decorator fixer.
+By default, the fixer adds jsdoc tags. Specifying the `decorator` option will also change that to use decorators.
 
-#### PascalCase `@Override` decorator fixer
+#### PascalCase `@Override` fixer
 
-When the `decorator` option is passed, linting will accept both `@override` and `@Override`, but the fixer defaults to adding `@override`. This can be changed with the `pascal-case-decorator` option.
+Linting will accept both `@override` and `@Override` jsdoc tags or decorators, but the fixer defaults to adding `@override`. This can be changed with the `pascal-case-fixer` option.
 
 ```json
 {
@@ -121,12 +121,12 @@ When the `decorator` option is passed, linting will accept both `@override` and 
         "tslint-override"
     ],
     "rules": {
-        "explicit-override": [ true, "decorator", "pascal-case-decorator" ]
+        "explicit-override": [ true, "pascal-case-fixer" ]
     }
 }
 ```
 
-`tslint-override/register` does not support the `@Override` decorator, so you will have to define the decorator yourself.
+Note: `tslint-override/register` does not support the PascalCase `@Override` decorator, so you will have to define it yourself.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ function override(_target: any, _propertyKey: string, _descriptor?: PropertyDesc
 
 If your love for java will never die, you can define this with a capital 'O' and use `@Override` in your code instead.
 
----
+### Enforcing either jsdoc tags or decorators
 
 Both jsdoc tags and decorators are accepted by default. If you want to force one and ignore the other, specify either the `decorator` or `jsdoc` parameter like this:
 
@@ -108,6 +108,27 @@ Both jsdoc tags and decorators are accepted by default. If you want to force one
         "explicit-override": [ true, "decorator" ]
     }
 ```
+
+By default, the fixer will add a jsdoc tag, specifying the `decorator` option will also use the decorator fixer.
+
+#### PascalCase `@Override` decorator fixer
+
+When the `decorator` option is passed, linting will accept both `@override` and `@Override`, but the fixer defaults to adding `@override`. This can be changed with the `pascal-case-decorator` option.
+
+```json
+{
+    "extends": [
+        "tslint-override"
+    ],
+    "rules": {
+        "explicit-override": [ true, "decorator", "pascal-case-decorator" ]
+    }
+}
+```
+
+`tslint-override/register` does not support the `@Override` decorator, so you will have to define the decorator yourself.
+
+---
 
 ### IDE support
 

--- a/rules/explicitOverrideRule.ts
+++ b/rules/explicitOverrideRule.ts
@@ -26,6 +26,8 @@ function isSomeClassElement(el: ts.Node): el is AllClassElements {
 const OPTION_DECORATOR = 'decorator';
 const OPTION_JSDOC_TAG = 'jsdoc';
 const OPTION_EXCLUDE_INTERFACES = 'exclude-interfaces';
+const OPTION_NAME_LOWERCASE = '@override';
+const OPTION_NAME_UPPERCASE = '@Override';
 
 const MESSAGE_EXTRA_CONSTRUCTOR = 'Extraneous override keyword: constructors always override the parent';
 const MESSAGE_EXTRA_STATIC = 'Extraneous override keyword: static members cannot override';
@@ -37,6 +39,8 @@ interface IOptions {
     useJsdocTag: boolean;
     useDecorator: boolean;
     excludeInterfaces: boolean;
+    lowercase: boolean;
+    uppercase: boolean;
 }
 
 export class Rule extends Lint.Rules.TypedRule {
@@ -54,15 +58,17 @@ export class Rule extends Lint.Rules.TypedRule {
             * \`"${OPTION_DECORATOR}"\` Uses a decorator: \`@override method() { }\`
             * \`"${OPTION_JSDOC_TAG}"\` (default) Uses a jsdoc tag: \`/** @override */ method() { }\`
             * \`"${OPTION_EXCLUDE_INTERFACES}"\` Exclude interfaces from member override checks (default: false)
+            * \`"${OPTION_NAME_LOWERCASE}"\` (default) If using decorators, uses the lowercase version: \`@override\`
+            * \`"${OPTION_NAME_UPPERCASE}"\` If using decorators, uses the uppercase version: \`@Override\`
         `,
         options: {
             type: 'array',
             items: {
                 type: 'string',
-                enum: [OPTION_DECORATOR, OPTION_JSDOC_TAG, OPTION_EXCLUDE_INTERFACES],
+                enum: [OPTION_DECORATOR, OPTION_JSDOC_TAG, OPTION_EXCLUDE_INTERFACES, OPTION_NAME_LOWERCASE, OPTION_NAME_UPPERCASE],
             },
             minLength: 1,
-            maxLength: 3,
+            maxLength: 4,
         },
         optionExamples: [[true, OPTION_DECORATOR]],
         type: 'typescript',
@@ -74,17 +80,20 @@ export class Rule extends Lint.Rules.TypedRule {
         const hasJsDocParameter = this.ruleArguments.indexOf(OPTION_JSDOC_TAG) !== -1;
         const hasDecoratorParameter = this.ruleArguments.indexOf(OPTION_DECORATOR) !== -1;
         const hasExcludeInterfacesParameter = this.ruleArguments.indexOf(OPTION_EXCLUDE_INTERFACES) !== -1;
+        const hasLowercaseParameter = this.ruleArguments.indexOf(OPTION_NAME_LOWERCASE) !== -1;
+        const hasUppercaseParameter = this.ruleArguments.indexOf(OPTION_NAME_UPPERCASE) !== -1;
         return this.applyWithWalker(
             new Walker(sourceFile, this.ruleName, {
                 useDecorator: hasDecoratorParameter || !hasJsDocParameter,
                 useJsdocTag: hasJsDocParameter || !hasDecoratorParameter,
-                excludeInterfaces: hasExcludeInterfacesParameter
+                excludeInterfaces: hasExcludeInterfacesParameter,
+                lowercase: hasLowercaseParameter || !hasUppercaseParameter,
+                uppercase: hasUppercaseParameter
             }, program.getTypeChecker()));
     }
 }
 
 const OVERRIDE_KEYWORD = 'override';
-const OVERRIDE_DECORATOR_MATCHER = /^@[oO]verride(\(\s*\))?$/;
 
 type HeritageChainCheckResult = {
     baseClass?: ts.Type;
@@ -93,12 +102,16 @@ type HeritageChainCheckResult = {
 
 class Walker extends Lint.AbstractWalker<IOptions> {
 
+    private readonly decoratorMatcher: RegExp;
+
     constructor(
             sourceFile: ts.SourceFile,
             ruleName: string,
             private readonly _options: IOptions,
             private readonly checker: ts.TypeChecker) {
         super(sourceFile, ruleName, _options);
+
+        this.decoratorMatcher = new RegExp(`^@${_options.lowercase ? 'override' : 'Override'}(\(\s*\))?$`);
     }
 
     /** @override */
@@ -190,7 +203,7 @@ class Walker extends Lint.AbstractWalker<IOptions> {
     }
 
     private fixWithDecorator(node: AllClassElements) {
-        return Lint.Replacement.appendText(node.getStart(), '@override ');
+        return Lint.Replacement.appendText(node.getStart(), this._options.lowercase ? '@override ' : '@Override ');
     }
 
     private fixWithJSDocTag(node: AllClassElements) {
@@ -284,7 +297,7 @@ class Walker extends Lint.AbstractWalker<IOptions> {
     }
 
     private checkIndividualDecorator(dec: ts.Decorator, found: boolean) {
-        if (!OVERRIDE_DECORATOR_MATCHER.test(dec.getText())) {
+        if (!this.decoratorMatcher.test(dec.getText())) {
             return;
         }
         if (found) {


### PR DESCRIPTION
How about we try #17 again

Closes #14 

Sorry about the git mess 😕 

#### Original PR text:

Example usage:

```json
{
    "extends": [
        "tslint-override"
    ],
    "rules": {
        "explicit-override": [ true, "decorator", "@Override" ]
    }
}
```

Note: This changes the decorator matcher to only work with the decorator of the correct casing. With that in mind, it may be a good idea to add another warning if we see a decorator with the wrong casing, and maybe change those to the correct casing? Should that be an additional option, tho?

Another note: I was going to write some tests for this but I wasn't quite sure how I should do it (especially since I wasn't sure how we want to handle the incorrect casing thing).