### PR TITLE
feat: Web Worker Support

### DIFF
--- a/angular-register.ts
+++ b/angular-register.ts
@@ -1,7 +1,11 @@
 // tslint:disable callable-types
 // tslint:disable variable-name
 
-declare type NoopDecorator = () => (_target: any, _propertyKey: string, _descriptor?: PropertyDescriptor) => void;
+declare type NoopDecorator = () => (
+  _target: Object,
+  _propertyKey: string,
+  _descriptor?: PropertyDescriptor
+) => void;
 
 declare var global: NodeJS.Global;
 declare global {
@@ -35,7 +39,7 @@ declare global {
 }
 
 export const ctx =
-  typeof global === 'undefined' ? (typeof window === 'undefined' ? undefined : window) : global;
+  typeof global === 'undefined' ? (typeof self === 'undefined' ? undefined : self) : global;
 export const override: NoopDecorator = () => () => { /* noop */ };
 export const Override: NoopDecorator = () => () => { /* noop */ };
 

--- a/angular-register.ts
+++ b/angular-register.ts
@@ -34,6 +34,12 @@ declare global {
   }
 }
 
-export const ctx = typeof global === 'undefined' ? window : global;
-ctx.override = () => () => { /* noop */ };
-ctx.Override = () => () => { /* noop */ };
+export const ctx =
+  typeof global === 'undefined' ? (typeof window === 'undefined' ? undefined : window) : global;
+export const override: NoopDecorator = () => () => { /* noop */ };
+export const Override: NoopDecorator = () => () => { /* noop */ };
+
+if (ctx) {
+  ctx.override = override;
+  ctx.Override = Override;
+}

--- a/angular-register.ts
+++ b/angular-register.ts
@@ -1,10 +1,8 @@
-/// <reference lib="webworker" />
-
 // tslint:disable callable-types
 // tslint:disable variable-name
 
 declare type NoopDecorator = () => (
-  _target: Object,
+  _target: object,
   _propertyKey: string,
   _descriptor?: PropertyDescriptor
 ) => void;

--- a/angular-register.ts
+++ b/angular-register.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 // tslint:disable callable-types
 // tslint:disable variable-name
 
@@ -26,6 +28,11 @@ declare global {
   var Override: NoopDecorator;
 
   interface Window {
+    override: NoopDecorator;
+    Override: NoopDecorator;
+  }
+
+  interface WorkerGlobalScope {
     override: NoopDecorator;
     Override: NoopDecorator;
   }

--- a/register.ts
+++ b/register.ts
@@ -1,30 +1,54 @@
+// tslint:disable callable-types
+// tslint:disable variable-name
 
+declare type NoopDecorator = (
+  _target: object,
+  _propertyKey: string,
+  _descriptor?: PropertyDescriptor
+) => void;
+
+declare var global: NodeJS.Global;
 declare global {
+  /**
+   * Indicates that this function or variable is being overridden
+   * from the implemented or extended parent class.
+   *
+   * @see [TSLint Override](https://github.com/hmil/tslint-override)
+   */
+  var override: NoopDecorator;
 
-    /**
-     * Specifies that this member must override a parent member.
-     */
-    const override: (_target: any, _propertyKey: string, _descriptor?: PropertyDescriptor) => void;
+  /**
+   * Indicates that this function or variable is being overridden
+   * from the implemented or extended parent class.
+   *
+   * @see [TSLint Override](https://github.com/hmil/tslint-override)
+   */
+  var Override: NoopDecorator;
 
-    interface Window {
-        override: (_target: any, _propertyKey: string, _descriptor?: PropertyDescriptor) => void;
+  interface Window {
+    override: NoopDecorator;
+    Override: NoopDecorator;
+  }
+
+  interface WorkerGlobalScope {
+    override: NoopDecorator;
+    Override: NoopDecorator;
+  }
+
+  namespace NodeJS {
+    interface Global {
+      override: NoopDecorator;
+      Override: NoopDecorator;
     }
-
-    namespace NodeJS {
-        interface Global {
-            override: (_target: any, _propertyKey: string, _descriptor?: PropertyDescriptor) => void;
-        }
-    }
+  }
 }
 
-export const ctx = typeof window !== 'undefined' ?
-    window : global;
+export const ctx =
+  typeof global === 'undefined' ? (typeof self === 'undefined' ? undefined : self) : global;
+export const override: NoopDecorator = () => { /* noop */ };
+export const Override: NoopDecorator = () => { /* noop */ };
 
-/**
- * Specifies that this member must override a parent member.
- */
-export function override(_target: any, _propertyKey: string, _descriptor?: PropertyDescriptor) {
-    // noop
+if (ctx) {
+  ctx.override = override;
+  ctx.Override = Override;
 }
-
-ctx.override = override;

--- a/rules/explicitOverrideRule.ts
+++ b/rules/explicitOverrideRule.ts
@@ -374,7 +374,7 @@ class Walker extends Lint.AbstractWalker<IOptions> {
     private checkHeritageChain(declaration: ts.ClassDeclaration | ts.ClassExpression, node: OverrideableElement)
             : HeritageChainCheckResult {
 
-        let baseInterface: ts.Type | undefined;
+        let baseInterface: ts.Type | undefined;
         let baseClass: ts.Type | undefined;
 
         const currentDeclaration = declaration;


### PR DESCRIPTION
- Doesn't assume that `window` is defined when `global` is undefined
- Exports `Override()` and `override()` so they can be imported in the cases where they aren't defined globally (like in Web Workers)

fixes: #33

- [x] Prevent Errors when running `angular-register` inside of a Web Worker
- [x] Access `@Override()` and `@override()` from the Web Worker global
- [x] ~~Register at the main entry point rather then for each worker~~
- [x] Apply the same fixes to `register`