### PR TITLE
fix: Source Code Encoding

### DIFF
--- a/rules/explicitOverrideRule.ts
+++ b/rules/explicitOverrideRule.ts
@@ -374,7 +374,7 @@ class Walker extends Lint.AbstractWalker<IOptions> {
     private checkHeritageChain(declaration: ts.ClassDeclaration | ts.ClassExpression, node: OverrideableElement)
             : HeritageChainCheckResult {
 
-        let baseInterface: ts.Type | undefined;
+        let baseInterface: ts.Type | undefined;
         let baseClass: ts.Type | undefined;
 
         const currentDeclaration = declaration;


### PR DESCRIPTION
It seesm that including got screwy here at some point and resulted in a strange `Â `

This repalces that with a ` ` so errors don't occur in VS Code.

Signed-off-by: William Sedlacek <wsedlacekc@gmail.com>